### PR TITLE
Fix Doxygen typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ while also embracing existing standards such as MQTT and XCP via Ethernet.
 
 - [Downloads →](https://docs.opendaq.com)
 - [User documentation →](https://opendaq.github.io/)
-- [API documentation (Doxgen) →](https://docs.opendaq.com/doxygen/index.html)
+- [API documentation (Doxygen) →](https://docs.opendaq.com/doxygen/index.html)
 
 ## Documentation
 


### PR DESCRIPTION
## Brief
- fix Doxygen typo in README

## Description
https://chatgpt.com/codex/tasks/task_e_684630d17ec88322afa0f8181c9591ee